### PR TITLE
Add regex to support pre-released SNAPSHOT versions

### DIFF
--- a/src/validator.ts
+++ b/src/validator.ts
@@ -8,7 +8,7 @@ const jsv = new jsonschema.Validator();
 const repositories = new Set();
 
 /* tslint:disable:max-line-length */
-const SCHEMA_PATTERN = /^iglu:([a-zA-Z0-9_.-]+)\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+)\/([1-9][0-9]*(?:-(?:0|[1-9][0-9]*)){2})$/;
+const SCHEMA_PATTERN = /^iglu:([a-zA-Z0-9_.-]+)\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+)\/((?:0|[1-9][0-9]*)(?:-(?:0|[1-9][0-9]*)){2}(?:-[a-zA-Z0-9_-]+)?)$/;
 
 const syncRepos = () => {
     repositories.clear();


### PR DESCRIPTION
Changed regular expression to support pre-released SNAPSHOT versions. This changed the regex in two ways. First it allows a MAJOR version of 0. Second it allows free text at the end for snapshot versions.

For example: `iglu:com.example.com/PageViewEvent/json-schema/0-0-1-BRANCH-SNAPSHOT`

Related open issue https://github.com/snowflake-analytics/chrome-snowplow-inspector/issues/11

Tested expression here: https://www.regextester.com/?fam=103375